### PR TITLE
Bug fixes: missing 'append' to stderr in cleanup call prevents viewing.

### DIFF
--- a/leader/solver
+++ b/leader/solver
@@ -41,11 +41,11 @@ def reverse_function(x):
 
 # total number of *local* slots (MPI processes) on this machine
 def get_num_local_slots():
-    return 4 # only for testing!!
-    # if pipeline_mode == PipelineMode.HUNDRED_MACHINES_16HWT_PAR_PPROD:
-    #     return 4 # distributed setup: 16/4 = 4 slots
-    # else:
-    #     return 16 # shared-memory setup: 64/4 = 16 slots
+    # return 4 # only for testing!!
+    if pipeline_mode == PipelineMode.HUNDRED_MACHINES_16HWT_PAR_PPROD:
+        return 4 # distributed setup: 16/4 = 4 slots
+    else:
+        return 16 # shared-memory setup: 64/4 = 16 slots
 
 # total time to run in seconds.  This allows ~1 minute of gracetime before ATS would pull the plug.
 TOTAL_TIME = 4940
@@ -278,7 +278,7 @@ def main():
             runner.logger.info(f"Checker return code was zero.  Check successful!")
                     
     # clean up.
-    runner.run(['/competition/cleanup'], True)
+    runner.run(['/competition/cleanup'], time_remaining, True)
     
     solver_output = {
         "return_code": return_code,


### PR DESCRIPTION
Fixed a missing 'append' which caused stderr to be unviewable beyond the cleanup script.
Also, use the # of cores per machine to be set programmatically rather than hard-coded.